### PR TITLE
Add frontend example and improve installer guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ O comando deve ser executado na raiz do repositório.
 
 Utilize o script `installer.py` para configurar um front-end que consome os serviços descritos nesta documentação e garantir que o pacote `baileys` será instalado.
 
+> 💡 Este repositório inclui um exemplo mínimo em `frontend/` com `package.json`, scripts de build/start e um serviço `baileys-service.js`. Use-o para validar o fluxo do instalador ou como referência para adaptar o seu projeto.
+
 ### Pré-requisitos
 
 - Python 3.8+
@@ -35,22 +37,26 @@ Utilize o script `installer.py` para configurar um front-end que consome os serv
 ### Uso básico
 
 ```bash
+# Use o projeto de exemplo
 python installer.py --frontend-path frontend/
+
+# OU aponte para um projeto Node.js existente
+python installer.py --frontend-path caminho/para/seu/projeto
 ```
 
-O comando acima irá:
+O comando acima executa uma sequência de etapas no diretório informado:
 
-1. Validar a presença do Node.js/npm.
-2. Executar `npm install` no diretório informado.
-3. Garantir que o pacote `baileys` está instalado como dependência (`npm install baileys`).
-4. Executar `npm run build`.
-5. Iniciar `npm run start` e, em paralelo, tentar iniciar `node baileys-service.js` dentro do diretório do front-end usando a porta `3002` via variável de ambiente `BAILEYS_PORT`.
+1. **Validação do ambiente Node.js** – garante que `node` e `npm` estão disponíveis, pois são obrigatórios para gerenciar o front-end.
+2. **Instalação de dependências** – roda `npm install` para baixar as dependências do projeto e, em seguida, força a instalação do pacote `baileys` com `npm install baileys` para assegurar sua presença.
+3. **Build do front-end** – executa `npm run build`, permitindo que você rode qualquer processo de build definido no seu `package.json` (no exemplo incluso, apenas imprime uma mensagem).
+4. **Inicialização do front-end** – aciona `npm run start`, útil para levantar o servidor do seu aplicativo (o exemplo disponibiliza um servidor HTTP simples).
+5. **Serviço Baileys auxiliar** – inicia `node baileys-service.js` (ou o comando definido via `--baileys-command`) com a variável `BAILEYS_PORT` apontando para a porta especificada, simulando a camada de integração com o Baileys.
 
 O script aguarda a finalização das execuções iniciadas; encerre com `Ctrl+C` quando não forem mais necessárias.
 
 ### Parâmetros disponíveis
 
-- `--frontend-path`: caminho para o diretório do front-end (padrão: `frontend`).
+- `--frontend-path`: caminho para o diretório do front-end (padrão: `frontend`). Se você não possui um projeto próprio, utilize o exemplo incluso ou ajuste este caminho para apontar para o seu projeto Node.js.
 - `--port`: porta utilizada pelo serviço Baileys (padrão: `3002`).
 - `--baileys-command`: substitui o comando padrão (`node baileys-service.js`). Informe após a flag todo o comando que deseja executar.
 - `--skip-build`, `--skip-start`, `--skip-baileys`: permitem pular etapas específicas do fluxo padrão.

--- a/frontend/baileys-service.js
+++ b/frontend/baileys-service.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const http = require('http');
+
+const port = process.env.BAILEYS_PORT || 3002;
+
+const server = http.createServer((_, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify({ status: 'ok', message: 'Serviço Baileys de exemplo ativo.' }));
+});
+
+server.listen(port, () => {
+  console.log(`Serviço Baileys de exemplo aguardando conexões na porta ${port}`);
+});
+
+process.on('SIGINT', () => {
+  console.log('Encerrando serviço Baileys de exemplo...');
+  server.close(() => process.exit(0));
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "whatsapp-docs-frontend-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Exemplo mínimo de front-end para uso com installer.py.",
+  "scripts": {
+    "build": "node scripts/build.js",
+    "start": "node scripts/start.js"
+  }
+}

--- a/frontend/scripts/build.js
+++ b/frontend/scripts/build.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('Build do front-end de exemplo executado. Adapte este script para o seu projeto real.');

--- a/frontend/scripts/start.js
+++ b/frontend/scripts/start.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const http = require('http');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((_, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Front-end de exemplo rodando. Substitua este script pelo seu app real.\n');
+});
+
+server.listen(port, () => {
+  console.log(`Servidor de exemplo iniciado em http://localhost:${port}`);
+});
+
+process.on('SIGINT', () => {
+  console.log('Encerrando servidor de exemplo...');
+  server.close(() => process.exit(0));
+});

--- a/installer.py
+++ b/installer.py
@@ -185,7 +185,15 @@ def main() -> None:
     logging.info("Diretório do front-end: %s", frontend_path)
     if not frontend_path.exists() or not frontend_path.is_dir():
         logging.error("Diretório do front-end não existe: %s", frontend_path)
-        raise SystemExit(1)
+        logging.error(
+            "Use --frontend-path para apontar para um projeto Node.js válido ou utilize o exemplo em ./frontend descrito no README.md."
+        )
+        logging.error(
+            "Consulte a seção 'Automatizando a preparação do front-end' no README para detalhes sobre o fluxo completo."
+        )
+        raise SystemExit(
+            "Caminho do front-end inválido. Ajuste o parâmetro --frontend-path conforme a documentação."
+        )
 
     ensure_node_and_npm()
     install_dependencies(frontend_path)


### PR DESCRIPTION
## Summary
- add a minimal Node.js example under frontend/ to validate the installer flow
- expand the README with guidance on using --frontend-path and detailing each installer step
- improve the installer error message when the frontend path is missing, pointing to the new documentation

## Testing
- python -m compileall installer.py

------
https://chatgpt.com/codex/tasks/task_e_68d35657e20c832f81eb17cdcb929302