### PR TITLE
Definir BAILEYS_PORT explicitamente no serviço Baileys

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -160,11 +160,12 @@ def get_baileys_command(args: argparse.Namespace, frontend_path: Path) -> List[s
 
 def run_baileys_service(args: argparse.Namespace, frontend_path: Path) -> None:
     env = os.environ.copy()
-    env.setdefault("BAILEYS_PORT", str(args.port))
+    env["BAILEYS_PORT"] = str(args.port)
     command = get_baileys_command(args, frontend_path)
+    baileys_port = env["BAILEYS_PORT"]
     logging.info(
-        "Iniciando serviço Baileys na porta %s com comando: %s",
-        args.port,
+        "Iniciando serviço Baileys com BAILEYS_PORT=%s e comando: %s",
+        baileys_port,
         " ".join(command),
     )
     try:


### PR DESCRIPTION
## Summary
- definir explicitamente a variável de ambiente BAILEYS_PORT ao iniciar o serviço auxiliar
- registrar no log a porta aplicada após a atribuição, junto ao comando executado

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d359b1a11c832fb2e324fd77f0ea3d