### PR TITLE
Serve Swagger UI frontend

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>API Documentation</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5.10.3/swagger-ui.css"
+    />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5.10.3/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+    <script>
+      window.addEventListener('load', () => {
+        SwaggerUIBundle({
+          url: '/openapi.yaml',
+          dom_id: '#swagger-ui',
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/frontend/scripts/start.js
+++ b/frontend/scripts/start.js
@@ -1,18 +1,63 @@
 #!/usr/bin/env node
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
 
 const port = process.env.PORT || 3000;
+const publicDir = path.resolve(__dirname, '..', 'public');
+const indexPath = path.join(publicDir, 'index.html');
+const openApiPath = path.resolve(__dirname, '..', '..', 'docs', 'swagger', 'openapi.yaml');
 
-const server = http.createServer((_, res) => {
-  res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
-  res.end('Front-end de exemplo rodando. Substitua este script pelo seu app real.\n');
+const logRequest = (req, statusCode) => {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] ${req.method} ${req.url} -> ${statusCode}`);
+};
+
+const server = http.createServer((req, res) => {
+  if (req.method !== 'GET') {
+    res.writeHead(405, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      Allow: 'GET',
+    });
+    res.end('Method Not Allowed\n');
+    logRequest(req, 405);
+    return;
+  }
+
+  const { url } = req;
+  try {
+    if (url === '/' || url === '/index.html') {
+      const html = fs.readFileSync(indexPath);
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      logRequest(req, 200);
+      return;
+    }
+
+    if (url === '/openapi.yaml') {
+      const spec = fs.readFileSync(openApiPath);
+      res.writeHead(200, { 'Content-Type': 'application/yaml; charset=utf-8' });
+      res.end(spec);
+      logRequest(req, 200);
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not Found\n');
+    logRequest(req, 404);
+  } catch (error) {
+    console.error('Erro ao servir conteúdo:', error);
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Internal Server Error\n');
+    logRequest(req, 500);
+  }
 });
 
 server.listen(port, () => {
-  console.log(`Servidor de exemplo iniciado em http://localhost:${port}`);
+  console.log(`Servidor do Swagger UI disponível em http://localhost:${port}`);
 });
 
 process.on('SIGINT', () => {
-  console.log('Encerrando servidor de exemplo...');
+  console.log('Encerrando servidor...');
   server.close(() => process.exit(0));
 });


### PR DESCRIPTION
## Summary
- add Swagger UI HTML entry point that loads assets from the CDN and targets /openapi.yaml
- replace the sample HTTP server with one that serves the Swagger UI page and the OpenAPI document with detailed logging and method handling

## Testing
- node frontend/scripts/start.js
- curl http://localhost:3000/
- curl http://localhost:3000/openapi.yaml | head

------
https://chatgpt.com/codex/tasks/task_e_68d36410227c832f80c2903660b671c0