### PR TITLE
Add Baileys proxy handling to frontend server

### DIFF
--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -8,7 +8,9 @@ servers:
   - url: https://api.exemplo.com
     description: Ambiente de produção
   - url: http://localhost:3000
-    description: Ambiente de desenvolvimento
+    description: Ambiente de desenvolvimento (proxy para http://localhost:3002)
+  - url: http://localhost:3002
+    description: Servidor Baileys direto para testes locais
 security:
   - bearerAuth: []
 tags:


### PR DESCRIPTION
## Summary
- proxy API routes from the local Swagger UI server to the Baileys service
- forward response status, headers and body from the proxied service
- document the proxied development server and direct Baileys server in OpenAPI servers list

## Testing
- node --check frontend/scripts/start.js

------
https://chatgpt.com/codex/tasks/task_e_68d36b567cd8832fae2546eddfd88438