### PR TITLE
Allow cross-origin access to Baileys API

### DIFF
--- a/frontend/baileys-service.js
+++ b/frontend/baileys-service.js
@@ -354,6 +354,18 @@ async function bootstrap() {
   await manager.initExistingInstances();
 
   const app = express();
+  app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', 'GET,POST,DELETE,PATCH,OPTIONS');
+    res.header('Access-Control-Allow-Headers', 'Authorization,Content-Type,Accept');
+
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(204);
+    }
+
+    return next();
+  });
+
   app.use(express.json({ limit: '5mb' }));
   app.use(bearerAuthMiddleware);
 


### PR DESCRIPTION
## Summary
- allow the Baileys Express API to respond with permissive CORS headers
- respond to OPTIONS preflight requests so the panel and external tools can reach the API directly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3f593e858832f8d3b72ea323f3b60